### PR TITLE
Add missing dkan_feedback css.

### DIFF
--- a/dkan_feedback.module
+++ b/dkan_feedback.module
@@ -301,3 +301,10 @@ function dkan_feedback_strongarm_alter(&$data) {
     }
   }
 }
+
+/**
+ * Implements hook_page_alter().
+ */
+function dkan_feedback_page_alter(&$page) {
+  drupal_add_css(drupal_get_path('module', 'dkan_feedback') . '/templates/feedback/feedback.css');
+}


### PR DESCRIPTION
CSS for dkan_feedback is not getting loaded in new theme for some reason. This
is a temporary fix we need to figure out why that css is not getting loaded in
the normal way.

REF CIVIC-4184
# QA Steps
- [ ] Verify that dkan_feedback css is loaded.
