### PR TITLE
Remove user email from comment display

### DIFF
--- a/dkan_feedback.captcha.inc
+++ b/dkan_feedback.captcha.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_feedback.captcha.inc

--- a/dkan_feedback.features.defaultconfig.inc
+++ b/dkan_feedback.features.defaultconfig.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_feedback.features.defaultconfig.inc

--- a/dkan_feedback.features.field_base.inc
+++ b/dkan_feedback.features.field_base.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_feedback.features.field_base.inc

--- a/dkan_feedback.features.field_instance.inc
+++ b/dkan_feedback.features.field_instance.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_feedback.features.field_instance.inc
@@ -70,9 +71,8 @@ function dkan_feedback_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'hidden',
-        'module' => 'text',
         'settings' => array(),
-        'type' => 'text_default',
+        'type' => 'hidden',
         'weight' => 2,
       ),
       'search_result' => array(

--- a/dkan_feedback.features.inc
+++ b/dkan_feedback.features.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_feedback.features.inc

--- a/dkan_feedback.features.taxonomy.inc
+++ b/dkan_feedback.features.taxonomy.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_feedback.features.taxonomy.inc

--- a/dkan_feedback.field_group.inc
+++ b/dkan_feedback.field_group.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_feedback.field_group.inc
@@ -25,10 +26,9 @@ function dkan_feedback_field_group_info() {
     'children' => array(
       0 => 'og_group_ref',
       1 => 'body',
-      2 => 'field_contact_email',
-      3 => 'field_feedback_entity_reference',
-      4 => 'field_feedback_type',
-      5 => 'field_tags',
+      2 => 'field_feedback_entity_reference',
+      3 => 'field_feedback_type',
+      4 => 'field_tags',
     ),
     'format_type' => 'table',
     'format_settings' => array(

--- a/dkan_feedback.strongarm.inc
+++ b/dkan_feedback.strongarm.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_feedback.strongarm.inc

--- a/dkan_feedback.views_default.inc
+++ b/dkan_feedback.views_default.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_feedback.views_default.inc

--- a/dkan_feedback.views_default.inc
+++ b/dkan_feedback.views_default.inc
@@ -285,6 +285,13 @@ function dkan_feedback_views_default_views() {
   $handler->display->display_options['fields']['delete_node']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['delete_node']['hide_empty'] = TRUE;
   $handler->display->display_options['defaults']['sorts'] = FALSE;
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  $handler->display->display_options['sorts']['created']['exposed'] = TRUE;
+  $handler->display->display_options['sorts']['created']['expose']['label'] = 'Most Recent';
   /* Sort criterion: Vote results: Value */
   $handler->display->display_options['sorts']['value']['id'] = 'value';
   $handler->display->display_options['sorts']['value']['table'] = 'votingapi_cache';
@@ -295,12 +302,6 @@ function dkan_feedback_views_default_views() {
   $handler->display->display_options['sorts']['value']['exposed'] = TRUE;
   $handler->display->display_options['sorts']['value']['expose']['label'] = 'Most Voted';
   $handler->display->display_options['sorts']['value']['coalesce'] = 1;
-  /* Sort criterion: Content: Post date */
-  $handler->display->display_options['sorts']['created']['id'] = 'created';
-  $handler->display->display_options['sorts']['created']['table'] = 'node';
-  $handler->display->display_options['sorts']['created']['field'] = 'created';
-  $handler->display->display_options['sorts']['created']['exposed'] = TRUE;
-  $handler->display->display_options['sorts']['created']['expose']['label'] = 'Most Recent';
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Content: Published */


### PR DESCRIPTION
Updates:
- Removes display of user email
- Changes default sort order on feedback page to created date DESC see #14 