### PR TITLE
Feedback publishing and order

### DIFF
--- a/dkan_feedback.install
+++ b/dkan_feedback.install
@@ -76,3 +76,10 @@ function dkan_feedback_update_7001() {
 function dkan_feedback_update_7002() {
   variable_del('node_options_feedback');
 }
+
+/**
+ * Revert dkan_feedback to fix node options and items order.
+ */
+function dkan_feedback_update_7003() {
+  features_revert_module('dkan_feedback');
+}

--- a/dkan_feedback.strongarm.inc
+++ b/dkan_feedback.strongarm.inc
@@ -64,7 +64,7 @@ function dkan_feedback_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'diff_enable_revisions_page_node_feedback';
-  $strongarm->value = 1;
+  $strongarm->value = 0;
   $export['diff_enable_revisions_page_node_feedback'] = $strongarm;
 
   $strongarm = new stdClass();
@@ -132,13 +132,6 @@ function dkan_feedback_strongarm() {
   $strongarm->name = 'menu_parent_feedback';
   $strongarm->value = 'main-menu:0';
   $export['menu_parent_feedback'] = $strongarm;
-
-  $strongarm = new stdClass();
-  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
-  $strongarm->api_version = 1;
-  $strongarm->name = 'node_options_feedback';
-  $strongarm->value = array();
-  $export['node_options_feedback'] = $strongarm;
 
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */

--- a/dkan_feedback.views_default.inc
+++ b/dkan_feedback.views_default.inc
@@ -69,7 +69,7 @@ function dkan_feedback_views_default_views() {
     ),
     'changed' => array(
       'sortable' => 0,
-      'default_sort_order' => 'asc',
+      'default_sort_order' => 'desc',
       'align' => '',
       'separator' => '',
       'empty_column' => 0,
@@ -534,7 +534,7 @@ function dkan_feedback_views_default_views() {
   );
   $handler->display->display_options['sitename_title'] = 0;
   $handler->display->display_options['use_batch'] = 'batch';
-  $handler->display->display_options['segment_size'] = '100';  
+  $handler->display->display_options['segment_size'] = '100';
   $export['dkan_feedback_administration'] = $view;
 
   $view = new view();
@@ -701,7 +701,7 @@ function dkan_feedback_views_default_views() {
     ),
     'created' => array(
       'sortable' => 0,
-      'default_sort_order' => 'asc',
+      'default_sort_order' => 'desc',
       'align' => '',
       'separator' => '',
       'empty_column' => 0,

--- a/templates/feedback/feedback.css
+++ b/templates/feedback/feedback.css
@@ -128,6 +128,9 @@
 .view-feedback .views-exposed-form label {
   display: inline-block;
 }
+.view-feedback .views-exposed-form select.form-control {
+  max-width: 250px;
+}
 .view-feedback .views-exposed-form .views-exposed-widget .form-submit {
   font-size: 12px;
 }


### PR DESCRIPTION
Feedback nodes options for publishing and revisions were not fully removed before, so here we are removing those and also fixing the order in which the nodes appear in the feedback administration views.

## How to test:
- If a previous version of the module was installed, then run `drush updb`, it should revert the feature*. Otherwise, just install the module.
- [ ] Go to /admin/content/feedback, the items should be shown from newest to oldest in all the tabs.
- [ ] As an anonymous user, create a new feedback node, it shouldn't be published automatically (it shouldn't appear in the /feedback page).

*If there are still some things left unreverted, you should be able to safely run `drush fr dkan_feedback -y`